### PR TITLE
use the official version of triq

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Numerix.Mixfile do
       {:dialyxir, "~> 0.3.3", only: [:dev, :test]},
       {:excoveralls, "~> 0.5.4", only: :test},
       {:excheck, "~> 0.4.1", only: :test},
-      {:triq, github: "krestenkrab/triq", only: :test},
+      {:triq, github: "triqng/triq", only: :test},
       {:ex_doc, "~> 0.11", only: :dev},
       {:earmark, "~> 0.2.1", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -15,4 +15,4 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
-  "triq": {:git, "https://github.com/krestenkrab/triq.git", "c7306b8eaea133d52140cb828817efb5e50a3d52", []}}
+  "triq": {:git, "https://github.com/triqng/triq.git", "2c497398e020e06db8496f1d89f12481cc5adab9", []}}


### PR DESCRIPTION
problem: 
- the compilation of Numerix fails on Elixir 1.3 with current triq version 

solution: 
- take a more recent version of triq from triqng/trig repo