### PR TITLE
Quick fixes for 1.4 complaints re missing parens in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule Numerix.Mixfile do
       version: "0.4.2",
       elixir: "~> 1.3",
       source_url: "https://github.com/safwank/Numerix",
-      deps: deps,
-      package: package,
+      deps: deps(),
+      package: package(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
         "credo": :test,


### PR DESCRIPTION
Just cloned and built/tested, noticed the infamous deps + packages warnings regarding missing parens.  Figured I'd fix it real quickly.

Neat package, going to try using it for some lightweight ML projects!